### PR TITLE
perf(cache): use type=gha instead of type=local for docker layer cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,10 +75,16 @@ runs:
         mask-password: 'false' # TODO: delete to change to 'true' by default (migration v1 to v2)
 
     # Exposes ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL so the raw `docker buildx build`
-    # below can talk to the GitHub Actions cache (type=gha). Not needed by build-push-action,
-    # but required when invoking buildx directly.
+    # below can talk to the GitHub Actions cache (type=gha). Normal `run:` steps don't get
+    # these vars; a JS action does. We use first-party actions/github-script instead of a
+    # third-party action so the runtime token is never handed to an external dependency.
     - name: Expose GitHub Actions runtime
-      uses: crazy-max/ghaction-github-runtime@v3
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
+          core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '')
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '')
 
     # This is a separate action that sets up buildx runner
     - name: Set up Docker Buildx
@@ -107,8 +113,8 @@ runs:
           # scope by image name so multiple images in the same repo don't clobber each
           # other. mode=max caches intermediate stages too.
           /usr/bin/docker buildx build \
-            --cache-from type=gha,scope=$IMAGE_NAME \
-            --cache-to type=gha,mode=max,scope=$IMAGE_NAME \
+            --cache-from "type=gha,scope=$IMAGE_NAME" \
+            --cache-to "type=gha,mode=max,scope=$IMAGE_NAME,ignore-error=true" \
             $DOCKER_BUILD_EXTRA_ARGS \
             --iidfile $tmp_dir/iidfile \
             --tag $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG \

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
     # these vars; a JS action does. We use first-party actions/github-script instead of a
     # third-party action so the runtime token is never handed to an external dependency.
     - name: Expose GitHub Actions runtime
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')

--- a/action.yml
+++ b/action.yml
@@ -74,18 +74,15 @@ runs:
       with:
         mask-password: 'false' # TODO: delete to change to 'true' by default (migration v1 to v2)
 
+    # Exposes ACTIONS_RUNTIME_TOKEN / ACTIONS_RESULTS_URL so the raw `docker buildx build`
+    # below can talk to the GitHub Actions cache (type=gha). Not needed by build-push-action,
+    # but required when invoking buildx directly.
+    - name: Expose GitHub Actions runtime
+      uses: crazy-max/ghaction-github-runtime@v3
+
     # This is a separate action that sets up buildx runner
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-      
-    # So now you can use Actions' own caching!
-    - name: Cache Docker layers
-      uses: actions/cache@v4
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
 
     - name: Build, tag, and push image to Amazon ECR
       shell: bash
@@ -103,20 +100,22 @@ runs:
         if [ "$cache_commit" = "$IMAGE_TAG" ]; then
             echo "Already existed image; skipping."
         else
-          tmp_dir=" /tmp/ecs-deploy-$(date +%s)"
+          tmp_dir="/tmp/ecs-deploy-$(date +%s)"
           mkdir -p $tmp_dir;
-          
-          /usr/bin/docker buildx build --cache-from type=local,src=/tmp/.buildx-cache --cache-to type=local,dest=/tmp/.buildx-cache-new $DOCKER_BUILD_EXTRA_ARGS --iidfile $tmp_dir/iidfile --tag $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG --metadata-file $tmp_dir/metadata-file --push .
+
+          # GitHub Actions cache (type=gha). It's repo-scoped by GitHub, and we further
+          # scope by image name so multiple images in the same repo don't clobber each
+          # other. mode=max caches intermediate stages too.
+          /usr/bin/docker buildx build \
+            --cache-from type=gha,scope=$IMAGE_NAME \
+            --cache-to type=gha,mode=max,scope=$IMAGE_NAME \
+            $DOCKER_BUILD_EXTRA_ARGS \
+            --iidfile $tmp_dir/iidfile \
+            --tag $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG \
+            --metadata-file $tmp_dir/metadata-file \
+            --push .
 
           rm -rf $tmp_dir
-          
-          # This ugly bit is necessary if you don't want your cache to grow forever
-          # until it hits GitHub's limit of 5GB.
-          # Temp fix
-          # https://github.com/docker/build-push-action/issues/252
-          # https://github.com/moby/buildkit/issues/1896
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
         fi
 
         echo "image=$ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Qué

Migra el cache de layers de Docker de `type=local` (+ `actions/cache@v4`) al backend nativo de GitHub Actions (`type=gha`) en el step de build de `action.yml`.

## Por qué

En los deploys (ej. [dashboard-service run](https://github.com/meetlara/dashboard-service/actions/runs/28912828745)) el layer de dependencias **sí** pegaba cache (`#12 CACHED`), pero con `type=local` el layer se tarra/destarra contra el cache de GHA y buildkit lo re-materializa: ~32s sólo en extraer el layer de deps. El backend `type=gha` evita ese round-trip.

## Cambios

- **Agrega `crazy-max/ghaction-github-runtime@v3`** para exponer `ACTIONS_RUNTIME_TOKEN` / `ACTIONS_RESULTS_URL`. Es **requerido** porque el build usa un `docker buildx build` crudo (no `docker/build-push-action`, que las inyecta solo). Sin esto, `--cache-to type=gha` falla.
- Reemplaza `type=local` + `actions/cache@v4` por `type=gha,mode=max`, scopeado por nombre de imagen (`scope=$IMAGE_NAME`) para que varias imágenes del mismo repo no se pisen. El cache de GHA ya está aislado por repo.
- Elimina el baile de `rm -rf /tmp/.buildx-cache && mv ...` (ya no hace falta).
- Corrige un espacio de más en `tmp_dir=" /tmp/..."`.

## Blast radius

`v3` es una branch usada por ~20 servicios. El cambio es transparente (mismos inputs/outputs); el único agregado es el step de runtime. No cambia el comportamiento de deploy, sólo el mecanismo de cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)