### PR TITLE
fix(cache): make type=gha cache actually work (drop dead v1 URL) + remove unused test-db

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,6 @@ runs:
         script: |
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
           core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '')
-          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '')
 
     # This is a separate action that sets up buildx runner
     - name: Set up Docker Buildx

--- a/action.yml
+++ b/action.yml
@@ -32,13 +32,6 @@ inputs:
     description: Define the extra arguments that you will set to docker build command
     required: false
     default: ""
-  with_testing_db:
-    description: Wether is necessary a testing db or not
-    required: false
-    default: "false"
-  db_schemas:
-    description: DB schemas list to create separated by a space
-    required: false
   second_task_definition_path:
     description: Define the path to the Task Definition
     required: false
@@ -54,13 +47,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up test db
-      id: set-up-test-db
-      if: ${{ inputs.with_testing_db == 'true' }}
-      uses: meetlara/set-up-test-db@main
-      with:
-        db_schemas: ${{ inputs.db_schemas }}
-
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -111,10 +97,12 @@ runs:
 
           # GitHub Actions cache (type=gha). It's repo-scoped by GitHub, and we further
           # scope by image name so multiple images in the same repo don't clobber each
-          # other. mode=max caches intermediate stages too.
+          # other. NOTE: mode=max intentionally omitted — it triggers a 400 error against
+          # the GHA cache backend (docker/buildx#841). Default mode=min caches the same
+          # layers here anyway since the Dockerfile is single-stage.
           /usr/bin/docker buildx build \
             --cache-from "type=gha,scope=$IMAGE_NAME" \
-            --cache-to "type=gha,mode=max,scope=$IMAGE_NAME,ignore-error=true" \
+            --cache-to "type=gha,scope=$IMAGE_NAME,ignore-error=true" \
             $DOCKER_BUILD_EXTRA_ARGS \
             --iidfile $tmp_dir/iidfile \
             --tag $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG \


### PR DESCRIPTION
## Contexto

Follow-up de #11 (migración `type=local` → `type=gha`). Al validar con deploys reales a stg (file-employee-integration-service) el cache **nunca se poblaba**: import y export tiraban `400 "Our services aren't available right now"`.

## Causa raíz (confirmada end-to-end)

Exponíamos el **`ACTIONS_CACHE_URL`** (endpoint **v1**, deprecado y **apagado** por GitHub). Con esa var seteada, buildkit v0.30 le pegaba al servicio v1 muerto → 400 en import y export, y la cache nunca se escribía. Exponiendo **solo `ACTIONS_RESULTS_URL` (v2)**, funciona.

> Nota: `crazy-max/ghaction-github-runtime` también exporta `ACTIONS_CACHE_URL`, así que habría tenido el mismo bug. Hacerlo con `github-script` a mano nos dejó quitarlo quirúrgicamente.

## Cambios

1. **No exponer `ACTIONS_CACHE_URL`** — solo `ACTIONS_RESULTS_URL` + `ACTIONS_RUNTIME_TOKEN` (fuerza v2). ← el fix del 400.
2. **Sacar `mode=max`** de `--cache-to`. Además del bug [docker/buildx#841](https://github.com/docker/buildx/issues/841), para estos Dockerfiles single-stage `min` y `max` cachean lo mismo.
3. **Sacar el step `Set up test db`** + inputs `with_testing_db`/`db_schemas`. Ningún workflow lo usa (solo un template de cookiecutter, comentado), pero forzaba el pre-build de la imagen de `postgresql-action` (~9s en "Set up job").

## Validación (file-employee, stg)

| Run | Cache | Step deploy |
|-----|-------|-------------|
| Baseline (type=local, warm) | — | **101s** |
| gha frío (v2, export OK) | miss → puebla | 97s |
| **gha HIT (v2)** | hit | **15s** |

Con cache tibia, el layer `apt-get + pnpm install` sale `CACHED`. Los 15s son el caso ideal (árbol idéntico); un deploy real con cambios de código ronda ~45-55s (deps cacheado, `pnpm run build` se re-corre) — igual ~mitad del baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)