### PR TITLE
fix(cache): force gha version=2 + pin github-script to SHA (follow-up to #12)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,7 @@ runs:
     # these vars; a JS action does. We use first-party actions/github-script instead of a
     # third-party action so the runtime token is never handed to an external dependency.
     - name: Expose GitHub Actions runtime
-      uses: actions/github-script@v9
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: |
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '')
@@ -100,8 +100,8 @@ runs:
           # the GHA cache backend (docker/buildx#841). Default mode=min caches the same
           # layers here anyway since the Dockerfile is single-stage.
           /usr/bin/docker buildx build \
-            --cache-from "type=gha,scope=$IMAGE_NAME" \
-            --cache-to "type=gha,scope=$IMAGE_NAME,ignore-error=true" \
+            --cache-from "type=gha,version=2,scope=$IMAGE_NAME" \
+            --cache-to "type=gha,version=2,scope=$IMAGE_NAME,ignore-error=true" \
             $DOCKER_BUILD_EXTRA_ARGS \
             --iidfile $tmp_dir/iidfile \
             --tag $ECR_REGISTRY/$IMAGE_NAME:$IMAGE_TAG \


### PR DESCRIPTION
Follow-up de #12. Estos dos cambios de hardening se pushearon **después** de que #12 se mergeara, así que no entraron en el squash. v3 hoy funciona (es la config v2-only validada end-to-end), pero conviene sumar:

1. **`version=2` explícito** en `--cache-from`/`--cache-to`. Según los [docs](https://docs.docker.com/build/cache/backends/gha/), el backend gha defaultea a `version=1` salvo que `ACTIONS_CACHE_SERVICE_V2` esté en el env del proceso de buildx — y con `docker buildx` crudo ese flag no se expone. Sin `version=2`, un runner podría volver a caer en el endpoint v1 (apagado) → regresa el `400`. Fijarlo lo hace determinístico.
2. **Pin de `actions/github-script`** a su commit SHA de v9.0.0 (corre con `GITHUB_TOKEN`; evitar tag mutable). Comentario de CodeRabbit en lambda-deploy#4.

Sin cambios funcionales respecto de lo validado; solo robustez + seguridad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)