### PR TITLE
fix(cache): guard --cache-from on ACTIONS_RESULTS_URL (follow-up to #13)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,8 +99,12 @@ runs:
           # other. NOTE: mode=max intentionally omitted — it triggers a 400 error against
           # the GHA cache backend (docker/buildx#841). Default mode=min caches the same
           # layers here anyway since the Dockerfile is single-stage.
+          # --cache-from is guarded on ACTIONS_RESULTS_URL: a cache import error can be
+          # fatal to the build (moby/buildkit#2836), so we only attempt the import when
+          # the GHA cache runtime is actually available. Export stays best-effort via
+          # ignore-error. (IMAGE_NAME is an ECR repo name, no spaces, so it's safe unquoted.)
           /usr/bin/docker buildx build \
-            --cache-from "type=gha,version=2,scope=$IMAGE_NAME" \
+            ${ACTIONS_RESULTS_URL:+--cache-from type=gha,version=2,scope=$IMAGE_NAME} \
             --cache-to "type=gha,version=2,scope=$IMAGE_NAME,ignore-error=true" \
             $DOCKER_BUILD_EXTRA_ARGS \
             --iidfile $tmp_dir/iidfile \


### PR DESCRIPTION
Último pedacito que faltó: el guard de `--cache-from` se pusheó después de que #13 se mergeara, así que no entró. lambda-deploy ya lo tiene.

Un error de import de cache puede ser **fatal** para el build ([moby/buildkit#2836](https://github.com/moby/buildkit/issues/2836)) y no hay `ignore-error` para `--cache-from`. Con `${ACTIONS_RESULTS_URL:+...}` solo intentamos el import cuando el runtime del cache está disponible → si el backend está caído, degrada a cache miss en vez de romper el deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)